### PR TITLE
bumped version number to avoid libxmljs installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "test"
   },
   "dependencies": {
-    "libxmljs": "0.18.0",
+    "libxmljs": "0.18.7",
     "lodash": "^3.10.1",
     "path": "^0.12.7",
     "q": "^1.4.1",


### PR DESCRIPTION
Hello, I was receiving issues with installing the libxmljs library when trying to run npm install fhir. When bumping the version number to the latest the issue seems to be resolved.

Here was the error I was seeing before version bump:
```
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! libxmljs@0.18.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the libxmljs@0.18.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/agraff/.npm/_logs/2017-11-21T00_57_23_083Z-debug.log
```
