### PR TITLE
Fixes and additional features for JS validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+node_js:
+  - "6"
+  - "8"
 os:
  - linux
  - osx

--- a/test/data/dstu2/doc-manifest-diff-profile.json
+++ b/test/data/dstu2/doc-manifest-diff-profile.json
@@ -1,0 +1,138 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "IHE.MHD.DocumentManifest",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\r\n\tStructureDefinition for DocumentManifest as represented in the Provide and Query interactions in the \r\n    IHE IT Infrastructure Technical Framework Supplement <a href=\"http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)\">Mobile access to Health Documents (MHD) Rev. 2.3</a></div>"
+  },
+  "url": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.DocumentManifest",
+  "name": "IHE.MHD.DocumentManifest",
+  "title": "IHE MHD Profile on DocumentManifest (SubmissionSet)",
+  "status": "draft",
+  "experimental": false,
+  "date": "2017-12-21",
+  "publisher": "Integrating the Healthcare Enterprise (IHE)",
+  "contact": [
+    {
+      "name": "IHE",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://ihe.net"
+        }
+      ]
+    },
+    {
+      "name": "John Moehrke",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "JohnMoehrke@gmail.com"
+        }
+      ]
+    }
+  ],
+  "description": "Profile on DocumentManifest based on IHE IT Infrastructure Technical Framework Supplement - Mobile access to Health Documents (MHD) Rev. 2.3.  See http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)",
+  "copyright": "IHE http://www.ihe.net/Governance/#Intellectual_Property",
+  "fhirVersion": "3.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "DocumentManifest",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentManifest",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "DocumentManifest.masterIdentifier",
+        "path": "DocumentManifest.masterIdentifier",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.identifier",
+        "path": "DocumentManifest.identifier",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.status",
+        "path": "DocumentManifest.status",
+        "comment": "approved -> status=current\r\ndeprecated -> status=superseded"
+      },
+      {
+        "id": "DocumentManifest.type",
+        "path": "DocumentManifest.type",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.subject",
+        "path": "DocumentManifest.subject",
+        "comment": "Not a contained resource. URL Points to an existing Patient resource representing Affinity Domain Patient",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Patient"
+          }
+        ]
+      },
+      {
+        "id": "DocumentManifest.created",
+        "path": "DocumentManifest.created",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.author",
+        "path": "DocumentManifest.author",
+        "comment": "Contained author resource of type Practitioner with:\r\n* authorInstitution: Organization\r\n* authorPerson: Practitioner.identifier and Practitioner.name\r\n* authorRole:—Not supported in STU3\r\n* authorSpecialty: Practitioner.qualification\r\n* authorTelecommunication: Practitioner.telecom",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Organization"
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "DocumentManifest.source",
+        "path": "DocumentManifest.source",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.content.p[x]:pReference",
+        "path": "DocumentManifest.content.pReference",
+        "sliceName": "pReference",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.ProvideDocumentBundle.Minimal"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.ProvideDocumentBundle.Comprehensive"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.Query.Minimal.DocumentReference"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.Query.Comprehensive.DocumentReference"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+          }
+        ]
+      },
+      {
+        "id": "DocumentManifest.related",
+        "path": "DocumentManifest.related",
+        "comment": "These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values.",
+        "max": "0"
+      }
+    ]
+  }
+}

--- a/test/data/dstu2/doc-manifest.json
+++ b/test/data/dstu2/doc-manifest.json
@@ -1,0 +1,80 @@
+{
+  "resourceType": "DocumentManifest",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>Text</div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "a1",
+      "name": {
+        "family": [
+          "Dopplemeyer"
+        ],
+        "given": [
+          "Sherry"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "email",
+          "value": "john.doe@healthcare.example.org"
+        }
+      ],
+      "practitionerRole": [
+        {
+          "managingOrganization": {
+            "display": "Cleveland Clinic"
+          },
+          "role": {
+            "text": "Primary Surgon"
+          },
+          "specialty": [
+            {
+              "text": "Orthopedic"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "masterIdentifier": {
+    "system": "http://example.org/documents",
+    "value": "23425234234-2346"
+  },
+  "identifier": [
+    {
+      "system": "http://example.org/documents",
+      "value": "23425234234-2347"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/xcda"
+  },
+  "recipient": [
+    {
+      "reference": "Practitioner/xcda1"
+    }
+  ],
+  "type": {
+    "text": "History and Physical"
+  },
+  "author": [
+    {
+      "reference": "#a1"
+    }
+  ],
+  "created": "2004-12-25T23:50:50-05:00",
+  "source": "urn:oid:1.3.6.1.4.1.21367.2009.1.2.1",
+  "status": "current",
+  "description": "Physical",
+  "content": [
+    {
+      "pReference": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ]
+}

--- a/test/data/dstu2/doc-manifest_bad.json
+++ b/test/data/dstu2/doc-manifest_bad.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "DocumentManifest",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>Text</div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "a1",
+      "name": {
+        "family": [
+          "Dopplemeyer"
+        ],
+        "given": [
+          "Sherry"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "email",
+          "value": "john.doe@healthcare.example.org"
+        }
+      ],
+      "practitionerRole": [
+        {
+          "managingOrganization": {
+            "display": "Cleveland Clinic"
+          },
+          "role": {
+            "text": "Primary Surgon"
+          },
+          "specialty": [
+            {
+              "text": "Orthopedic"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "masterIdentifier": {
+    "system": "http://example.org/documents",
+    "value": "23425234234-2346"
+  },
+  "identifier": [
+    {
+      "system": "http://example.org/documents",
+      "value": "23425234234-2347"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/xcda"
+  },
+  "recipient": [
+    {
+      "reference": "Practitioner/xcda1"
+    }
+  ],
+  "type": {
+    "text": "History and Physical"
+  },
+  "author": [
+    {
+      "reference": "#a1"
+    }
+  ],
+  "created": "2004-12-25T23:50:50-05:00",
+  "source": "urn:oid:1.3.6.1.4.1.21367.2009.1.2.1",
+  "status": "current",
+  "description": "Physical",
+  "content": [
+    {
+      "pReference": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ],
+  "related": [
+    {
+      "identifier": {
+        "system": "http://example.org/documents",
+        "value": "23425234234-9999"
+      },
+      "ref": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ]
+}

--- a/test/data/stu3/doc-manifest-diff-profile.json
+++ b/test/data/stu3/doc-manifest-diff-profile.json
@@ -1,0 +1,138 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "IHE.MHD.DocumentManifest",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\r\n\tStructureDefinition for DocumentManifest as represented in the Provide and Query interactions in the \r\n    IHE IT Infrastructure Technical Framework Supplement <a href=\"http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)\">Mobile access to Health Documents (MHD) Rev. 2.3</a></div>"
+  },
+  "url": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.DocumentManifest",
+  "name": "IHE.MHD.DocumentManifest",
+  "title": "IHE MHD Profile on DocumentManifest (SubmissionSet)",
+  "status": "draft",
+  "experimental": false,
+  "date": "2017-12-21",
+  "publisher": "Integrating the Healthcare Enterprise (IHE)",
+  "contact": [
+    {
+      "name": "IHE",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://ihe.net"
+        }
+      ]
+    },
+    {
+      "name": "John Moehrke",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "JohnMoehrke@gmail.com"
+        }
+      ]
+    }
+  ],
+  "description": "Profile on DocumentManifest based on IHE IT Infrastructure Technical Framework Supplement - Mobile access to Health Documents (MHD) Rev. 2.3.  See http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)",
+  "copyright": "IHE http://www.ihe.net/Governance/#Intellectual_Property",
+  "fhirVersion": "3.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "DocumentManifest",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentManifest",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "DocumentManifest.masterIdentifier",
+        "path": "DocumentManifest.masterIdentifier",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.identifier",
+        "path": "DocumentManifest.identifier",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.status",
+        "path": "DocumentManifest.status",
+        "comment": "approved -> status=current\r\ndeprecated -> status=superseded"
+      },
+      {
+        "id": "DocumentManifest.type",
+        "path": "DocumentManifest.type",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.subject",
+        "path": "DocumentManifest.subject",
+        "comment": "Not a contained resource. URL Points to an existing Patient resource representing Affinity Domain Patient",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Patient"
+          }
+        ]
+      },
+      {
+        "id": "DocumentManifest.created",
+        "path": "DocumentManifest.created",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.author",
+        "path": "DocumentManifest.author",
+        "comment": "Contained author resource of type Practitioner with:\r\n* authorInstitution: Organization\r\n* authorPerson: Practitioner.identifier and Practitioner.name\r\n* authorRole:—Not supported in STU3\r\n* authorSpecialty: Practitioner.qualification\r\n* authorTelecommunication: Practitioner.telecom",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/Organization"
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "DocumentManifest.source",
+        "path": "DocumentManifest.source",
+        "min": 1
+      },
+      {
+        "id": "DocumentManifest.content.p[x]:pReference",
+        "path": "DocumentManifest.content.pReference",
+        "sliceName": "pReference",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.ProvideDocumentBundle.Minimal"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.ProvideDocumentBundle.Comprehensive"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.Query.Minimal.DocumentReference"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://ihe.net/fhir/StructureDefinition/IHE.MHD.Query.Comprehensive.DocumentReference"
+          },
+          {
+            "code": "Reference",
+            "targetProfile": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+          }
+        ]
+      },
+      {
+        "id": "DocumentManifest.related",
+        "path": "DocumentManifest.related",
+        "comment": "These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values.",
+        "max": "0"
+      }
+    ]
+  }
+}

--- a/test/data/stu3/doc-manifest.json
+++ b/test/data/stu3/doc-manifest.json
@@ -1,0 +1,80 @@
+{
+  "resourceType": "DocumentManifest",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>Text</div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "a1",
+      "name": {
+        "family": [
+          "Dopplemeyer"
+        ],
+        "given": [
+          "Sherry"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "email",
+          "value": "john.doe@healthcare.example.org"
+        }
+      ],
+      "practitionerRole": [
+        {
+          "managingOrganization": {
+            "display": "Cleveland Clinic"
+          },
+          "role": {
+            "text": "Primary Surgon"
+          },
+          "specialty": [
+            {
+              "text": "Orthopedic"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "masterIdentifier": {
+    "system": "http://example.org/documents",
+    "value": "23425234234-2346"
+  },
+  "identifier": [
+    {
+      "system": "http://example.org/documents",
+      "value": "23425234234-2347"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/xcda"
+  },
+  "recipient": [
+    {
+      "reference": "Practitioner/xcda1"
+    }
+  ],
+  "type": {
+    "text": "History and Physical"
+  },
+  "author": [
+    {
+      "reference": "#a1"
+    }
+  ],
+  "created": "2004-12-25T23:50:50-05:00",
+  "source": "urn:oid:1.3.6.1.4.1.21367.2009.1.2.1",
+  "status": "current",
+  "description": "Physical",
+  "content": [
+    {
+      "pReference": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ]
+}

--- a/test/data/stu3/doc-manifest_bad.json
+++ b/test/data/stu3/doc-manifest_bad.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "DocumentManifest",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>Text</div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "a1",
+      "name": {
+        "family": [
+          "Dopplemeyer"
+        ],
+        "given": [
+          "Sherry"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "email",
+          "value": "john.doe@healthcare.example.org"
+        }
+      ],
+      "practitionerRole": [
+        {
+          "managingOrganization": {
+            "display": "Cleveland Clinic"
+          },
+          "role": {
+            "text": "Primary Surgon"
+          },
+          "specialty": [
+            {
+              "text": "Orthopedic"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "masterIdentifier": {
+    "system": "http://example.org/documents",
+    "value": "23425234234-2346"
+  },
+  "identifier": [
+    {
+      "system": "http://example.org/documents",
+      "value": "23425234234-2347"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/xcda"
+  },
+  "recipient": [
+    {
+      "reference": "Practitioner/xcda1"
+    }
+  ],
+  "type": {
+    "text": "History and Physical"
+  },
+  "author": [
+    {
+      "reference": "#a1"
+    }
+  ],
+  "created": "2004-12-25T23:50:50-05:00",
+  "source": "urn:oid:1.3.6.1.4.1.21367.2009.1.2.1",
+  "status": "current",
+  "description": "Physical",
+  "content": [
+    {
+      "pReference": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ],
+  "related": [
+    {
+      "identifier": {
+        "system": "http://example.org/documents",
+        "value": "23425234234-9999"
+      },
+      "ref": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ]
+}

--- a/test/dstu2/validationTests.js
+++ b/test/dstu2/validationTests.js
@@ -29,9 +29,8 @@ describe('DSTU2: Validation', function() {
     describe('ValidateJSONResource()', function() {
         it('should validate bundle-transaction.json successfully', function() {
             var bundleJson = fs.readFileSync('./test/data/dstu2/bundle-transaction.json').toString('utf8');
-            var bundle = JSON.parse(bundleJson);
             var fhir = new Fhir(Fhir.DSTU2);
-            var result = fhir.ValidateJSResource(bundle);
+            var result = fhir.ValidateJSONResource(bundleJson);
 
             assert(result);
             assert.equal(result.valid, true);
@@ -43,15 +42,41 @@ describe('DSTU2: Validation', function() {
 
     describe('ValidateJSResource()', function() {
         it('should validate bundle-transaction.json successfully', function() {
-            var bundleJson = fs.readFileSync('./test/data/dstu2/bundle-transaction.json').toString('utf8');
+            var bundleJson = JSON.parse(fs.readFileSync('./test/data/dstu2/bundle-transaction.json').toString('utf8'));
             var fhir = new Fhir(Fhir.DSTU2);
-            var result = fhir.ValidateJSONResource(bundleJson);
+            var result = fhir.ValidateJSResource(bundleJson);
 
             assert(result);
             assert.equal(result.valid, true);
 
             assert(result.errors);
             assert.equal(result.errors.length, 0);
+        });
+
+        it('should validate with a differential profile sucessfully', function () {
+          var profile = JSON.parse(fs.readFileSync('./test/data/dstu2/doc-manifest-diff-profile.json').toString('utf8'));
+          var docManifest = JSON.parse(fs.readFileSync('./test/data/dstu2/doc-manifest.json').toString('utf8'));
+          var fhir = new Fhir(Fhir.DSTU2);
+          var result = fhir.ValidateJSResource(docManifest, profile);
+
+          assert(result);
+          assert.equal(result.valid, true);
+
+          assert(result.errors);
+          assert.equal(result.errors.length, 0);
+        });
+
+        it('should return errors when validating with a differential profile', function () {
+          var profile = JSON.parse(fs.readFileSync('./test/data/dstu2/doc-manifest-diff-profile.json').toString('utf8'));
+          var docManifest = JSON.parse(fs.readFileSync('./test/data/dstu2/doc-manifest_bad.json').toString('utf8'));
+          var fhir = new Fhir(Fhir.DSTU2);
+          var result = fhir.ValidateJSResource(docManifest, profile);
+
+          assert(result);
+          assert.equal(result.valid, false);
+
+          assert(result.errors);
+          assert.equal(result.errors.length, 1);
         });
     });
 });

--- a/test/stu3/validationTests.js
+++ b/test/stu3/validationTests.js
@@ -6,7 +6,7 @@ describe('STU3: Validation', function() {
     describe('ValidateXMLResource()', function() {
         it('should validate bundle-transaction successfully', function() {
             var bundleXml = fs.readFileSync('./test/data/stu3/bundle-transaction.xml').toString('utf8');
-            var fhir = new Fhir(Fhir.DSTU2);
+            var fhir = new Fhir(Fhir.STU3);
             var result = fhir.ValidateXMLResource(bundleXml);
 
             assert(result);
@@ -15,7 +15,7 @@ describe('STU3: Validation', function() {
 
         it('should return validation errors for bundle-transaction_bad', function() {
             var bundleXml = fs.readFileSync('./test/data/stu3/bundle-transaction_bad.xml').toString('utf8');
-            var fhir = new Fhir(Fhir.DSTU2);
+            var fhir = new Fhir(Fhir.STU3);
             var result = fhir.ValidateXMLResource(bundleXml);
 
             assert(result);
@@ -30,7 +30,7 @@ describe('STU3: Validation', function() {
         it('should validate bundle-transaction.json successfully', function() {
             var bundleJson = fs.readFileSync('./test/data/stu3/bundle-transaction.json').toString('utf8');
             var bundle = JSON.parse(bundleJson);
-            var fhir = new Fhir(Fhir.DSTU2);
+            var fhir = new Fhir(Fhir.STU3);
             var result = fhir.ValidateJSResource(bundle);
 
             assert(result);
@@ -43,15 +43,41 @@ describe('STU3: Validation', function() {
 
     describe('ValidateJSResource()', function() {
         it('should validate bundle-transaction.json successfully', function() {
-            var bundleJson = fs.readFileSync('./test/data/stu3/bundle-transaction.json').toString('utf8');
-            var fhir = new Fhir(Fhir.DSTU2);
-            var result = fhir.ValidateJSONResource(bundleJson);
+            var bundleJson = JSON.parse(fs.readFileSync('./test/data/stu3/bundle-transaction.json').toString('utf8'));
+            var fhir = new Fhir(Fhir.STU3);
+            var result = fhir.ValidateJSResource(bundleJson);
 
             assert(result);
             assert.equal(result.valid, true);
 
             assert(result.errors);
             assert.equal(result.errors.length, 0);
+        });
+
+        it('should validate with a differential profile sucessfully', function () {
+          var profile = JSON.parse(fs.readFileSync('./test/data/stu3/doc-manifest-diff-profile.json').toString('utf8'));
+          var docManifest = JSON.parse(fs.readFileSync('./test/data/stu3/doc-manifest.json').toString('utf8'));
+          var fhir = new Fhir(Fhir.STU3);
+          var result = fhir.ValidateJSResource(docManifest, profile);
+
+          assert(result);
+          assert.equal(result.valid, true);
+
+          assert(result.errors);
+          assert.equal(result.errors.length, 0);
+        });
+
+        it('should return errors when validating with a differential profile', function () {
+          var profile = JSON.parse(fs.readFileSync('./test/data/stu3/doc-manifest-diff-profile.json').toString('utf8'));
+          var docManifest = JSON.parse(fs.readFileSync('./test/data/stu3/doc-manifest_bad.json').toString('utf8'));
+          var fhir = new Fhir(Fhir.STU3);
+          var result = fhir.ValidateJSResource(docManifest, profile);
+
+          assert(result);
+          assert.equal(result.valid, false);
+
+          assert(result.errors);
+          assert.equal(result.errors.length, 1);
         });
     });
 });


### PR DESCRIPTION
Hi,

We are looking to use FHIS.js for validation and xml to js conversion for our FHIR server implementation https://github.com/jembi/hearth

We noticed a few problems with the current cardinality validation and we also needed a few extra features for our work:
  * Bug: The JS validation for DSTU2 and STU3 assumed that an elements cardinality values were in the `.definition` property, however, this is only true for DSTU1 definitions so no validation were running for DSTU2 and STU3.
  * Feature: Support for differential profiles over and above snapshot profiles
  * Feature: Add support for choice for types in validation as these were causing validation errors.

This PR resolves the above. Please let us know if there is anything else we need to do so that this can be merged.