### PR TITLE
Fix validation of booleans for required fields

### DIFF
--- a/dstu1/jsValidator.js
+++ b/dstu1/jsValidator.js
@@ -38,7 +38,7 @@ module.exports = function(profiles) {
             for (var x in current) {
                 var currentEval = eval('current[x][\'' + pathSplit[i] + '\']');
 
-                if (currentEval) {
+                if (typeof currentEval !== 'undefined') {
                     if (currentEval instanceof Array) {
                         next = next.concat(currentEval);
                     } else if (currentEval || currentEval == false) {

--- a/dstu2/jsValidator.js
+++ b/dstu2/jsValidator.js
@@ -48,7 +48,7 @@ module.exports = function(profiles) {
                   })
                 }
 
-                if (currentEval) {
+                if (typeof currentEval !== 'undefined') {
                     if (currentEval instanceof Array) {
                         next = next.concat(currentEval);
                     } else if (currentEval || currentEval == false) {

--- a/stu3/jsValidator.js
+++ b/stu3/jsValidator.js
@@ -48,7 +48,7 @@ module.exports = function(profiles) {
                   })
                 }
 
-                if (currentEval) {
+                if (typeof currentEval !== 'undefined') {
                     if (currentEval instanceof Array) {
                         next = next.concat(currentEval);
                     } else if (currentEval || currentEval == false) {

--- a/test/data/dstu1/immunization-example.json
+++ b/test/data/dstu1/immunization-example.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "Immunization",
+  "text": {
+    "status": "generated",
+    "div": "<div>Authored by Joginder Madra</div>"
+  },
+  "date": "2013-01-10",
+  "vaccineType": {
+    "coding": [
+      {
+        "code": "396427003"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "refusedIndicator": false,
+  "reported": false,
+  "performer": {
+    "reference": "Practitioner/example"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15"
+}

--- a/test/data/dstu2/immunization-example.json
+++ b/test/data/dstu2/immunization-example.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Immunization",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: completed</p><p><b>date</b>: 10/01/2013</p><p><b>vaccineCode</b>: Fluvax (Influenza) <span>(Details : {urn:oid:1.2.36.1.2001.1005.17 code 'FLUVAX' = '??)</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>wasNotGiven</b>: false</p><p><b>reported</b>: false</p><p><b>performer</b>: <a>Practitioner/example</a></p><p><b>requester</b>: <a>Practitioner/example</a></p><p><b>encounter</b>: <a>Encounter/example</a></p><p><b>manufacturer</b>: <a>Organization/hl7</a></p><p><b>location</b>: <a>Location/1</a></p><p><b>lotNumber</b>: AAJN11K</p><p><b>expirationDate</b>: 15/02/2015</p><p><b>site</b>: left arm <span>(Details : {http://hl7.org/fhir/v3/ActSite code 'LA' = 'left arm', given as 'left arm'})</span></p><p><b>route</b>: Injection, intramuscular <span>(Details : {http://hl7.org/fhir/v3/RouteOfAdministration code 'IM' = 'Injection, intramuscular', given as 'Injection, intramuscular'})</span></p><p><b>doseQuantity</b>: 5 mg<span> (Details: http://unitsofmeasure.org code mg = '??')</span></p><p><b>note</b>: Notes on adminstration of vaccine</p><h3>Explanations</h3><table><tr><td>-</td><td><b>Reason</b></td></tr><tr><td>*</td><td>429060002 <span>(Details : {SNOMED CT code '429060002' = '429060002)</span></td></tr></table><h3>Reactions</h3><table><tr><td>-</td><td><b>Date</b></td><td><b>Detail</b></td><td><b>Reported</b></td></tr><tr><td>*</td><td>10/01/2013</td><td><a>Observation/example</a></td><td>true</td></tr></table><h3>VaccinationProtocols</h3><table><tr><td>-</td><td><b>DoseSequence</b></td><td><b>Description</b></td><td><b>Authority</b></td><td><b>Series</b></td><td><b>SeriesDoses</b></td><td><b>TargetDisease</b></td><td><b>DoseStatus</b></td><td><b>DoseStatusReason</b></td></tr><tr><td>*</td><td>1</td><td>Vaccination Protocol Sequence 1</td><td><a>Organization/hl7</a></td><td>Vaccination Series 1</td><td>2</td><td>1857005 <span>(Details : {SNOMED CT code '1857005' = '1857005)</span></td><td>Counts <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status code 'count' = 'Counts', given as 'Counts'})</span></td><td>Cold chain break <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status-reason code 'coldchbrk' = 'Cold chain break', given as 'Cold chain break'})</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "completed",
+  "date": "2013-01-10",
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.36.1.2001.1005.17",
+        "code": "FLUVAX"
+      }
+    ],
+    "text": "Fluvax (Influenza)"
+  },
+  "patient": {
+    "reference": "Patient/example"
+  },
+  "wasNotGiven": false,
+  "reported": false,
+  "performer": {
+    "reference": "Practitioner/example"
+  },
+  "requester": {
+    "reference": "Practitioner/example"
+  },
+  "encounter": {
+    "reference": "Encounter/example"
+  },
+  "manufacturer": {
+    "reference": "Organization/hl7"
+  },
+  "location": {
+    "reference": "Location/1"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15",
+  "site": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ]
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ]
+  },
+  "doseQuantity": {
+    "value": 5,
+    "system": "http://unitsofmeasure.org",
+    "code": "mg"
+  },
+  "note": [
+    {
+      "text": "Notes on adminstration of vaccine"
+    }
+  ],
+  "explanation": {
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "429060002"
+          }
+        ]
+      }
+    ]
+  },
+  "reaction": [
+    {
+      "date": "2013-01-10",
+      "detail": {
+        "reference": "Observation/example"
+      },
+      "reported": true
+    }
+  ],
+  "vaccinationProtocol": [
+    {
+      "doseSequence": 1,
+      "description": "Vaccination Protocol Sequence 1",
+      "authority": {
+        "reference": "Organization/hl7"
+      },
+      "series": "Vaccination Series 1",
+      "seriesDoses": 2,
+      "targetDisease": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1857005"
+            }
+          ]
+        }
+      ],
+      "doseStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status",
+            "code": "count",
+            "display": "Counts"
+          }
+        ]
+      },
+      "doseStatusReason": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status-reason",
+            "code": "coldchbrk",
+            "display": "Cold chain break"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/data/stu3/immunization-example.json
+++ b/test/data/stu3/immunization-example.json
@@ -1,0 +1,157 @@
+{
+  "resourceType": "Immunization",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: completed</p><p><b>notGiven</b>: false</p><p><b>vaccineCode</b>: Fluvax (Influenza) <span>(Details : {urn:oid:1.2.36.1.2001.1005.17 code 'FLUVAX' = 'Fluvax)</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>encounter</b>: <a>Encounter/example</a></p><p><b>date</b>: 10/01/2013</p><p><b>primarySource</b>: true</p><p><b>location</b>: <a>Location/1</a></p><p><b>manufacturer</b>: <a>Organization/hl7</a></p><p><b>lotNumber</b>: AAJN11K</p><p><b>expirationDate</b>: 15/02/2015</p><p><b>site</b>: left arm <span>(Details : {http://hl7.org/fhir/v3/ActSite code 'LA' = 'left arm', given as 'left arm'})</span></p><p><b>route</b>: Injection, intramuscular <span>(Details : {http://hl7.org/fhir/v3/RouteOfAdministration code 'IM' = 'Injection, intramuscular', given as 'Injection, intramuscular'})</span></p><p><b>doseQuantity</b>: 5 mg<span> (Details: UCUM code mg = 'mg')</span></p><blockquote><p><b>practitioner</b></p><p><b>role</b>: Ordering Provider <span>(Details : {http://hl7.org/fhir/v2/0443 code 'OP' = 'Ordering Provider)</span></p><p><b>actor</b>: <a>Practitioner/example</a></p></blockquote><blockquote><p><b>practitioner</b></p><p><b>role</b>: Administering Provider <span>(Details : {http://hl7.org/fhir/v2/0443 code 'AP' = 'Administering Provider)</span></p><p><b>actor</b>: <a>Practitioner/example</a></p></blockquote><p><b>note</b>: Notes on adminstration of vaccine</p><h3>Explanations</h3><table><tr><td>-</td><td><b>Reason</b></td></tr><tr><td>*</td><td>Procedure to meet occupational requirement <span>(Details : {SNOMED CT code '429060002' = 'Procedure to meet occupational requirement)</span></td></tr></table><h3>Reactions</h3><table><tr><td>-</td><td><b>Date</b></td><td><b>Detail</b></td><td><b>Reported</b></td></tr><tr><td>*</td><td>10/01/2013</td><td><a>Observation/example</a></td><td>true</td></tr></table><h3>VaccinationProtocols</h3><table><tr><td>-</td><td><b>DoseSequence</b></td><td><b>Description</b></td><td><b>Authority</b></td><td><b>Series</b></td><td><b>SeriesDoses</b></td><td><b>TargetDisease</b></td><td><b>DoseStatus</b></td><td><b>DoseStatusReason</b></td></tr><tr><td>*</td><td>1</td><td>Vaccination Protocol Sequence 1</td><td><a>Organization/hl7</a></td><td>Vaccination Series 1</td><td>2</td><td>Gestational rubella syndrome <span>(Details : {SNOMED CT code '1857005' = 'Gestational rubella syndrome)</span></td><td>Counts <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status code 'count' = 'Counts', given as 'Counts'})</span></td><td>Cold chain break <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status-reason code 'coldchbrk' = 'Cold chain break', given as 'Cold chain break'})</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "completed",
+  "notGiven": false,
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.36.1.2001.1005.17",
+        "code": "FLUVAX"
+      }
+    ],
+    "text": "Fluvax (Influenza)"
+  },
+  "patient": {
+    "reference": "Patient/example"
+  },
+  "encounter": {
+    "reference": "Encounter/example"
+  },
+  "date": "2013-01-10",
+  "primarySource": true,
+  "location": {
+    "reference": "Location/1"
+  },
+  "manufacturer": {
+    "reference": "Organization/hl7"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15",
+  "site": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ]
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ]
+  },
+  "doseQuantity": {
+    "value": 5,
+    "system": "http://unitsofmeasure.org",
+    "code": "mg"
+  },
+  "practitioner": [
+    {
+      "role": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0443",
+            "code": "OP"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/example"
+      }
+    },
+    {
+      "role": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0443",
+            "code": "AP"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/example"
+      }
+    }
+  ],
+  "note": [
+    {
+      "text": "Notes on adminstration of vaccine"
+    }
+  ],
+  "explanation": {
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "429060002"
+          }
+        ]
+      }
+    ]
+  },
+  "reaction": [
+    {
+      "date": "2013-01-10",
+      "detail": {
+        "reference": "Observation/example"
+      },
+      "reported": true
+    }
+  ],
+  "vaccinationProtocol": [
+    {
+      "doseSequence": 1,
+      "description": "Vaccination Protocol Sequence 1",
+      "authority": {
+        "reference": "Organization/hl7"
+      },
+      "series": "Vaccination Series 1",
+      "seriesDoses": 2,
+      "targetDisease": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1857005"
+            }
+          ]
+        }
+      ],
+      "doseStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status",
+            "code": "count",
+            "display": "Counts"
+          }
+        ]
+      },
+      "doseStatusReason": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status-reason",
+            "code": "coldchbrk",
+            "display": "Cold chain break"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/dstu1/validationTests.js
+++ b/test/dstu1/validationTests.js
@@ -39,6 +39,18 @@ describe('DSTU1: Validation', function() {
             assert.equal(1, result.errors.length);
         });
 
+        it('should validate immunization-example.json successfully', function() {
+            var immunizationJson = JSON.parse(fs.readFileSync('./test/data/dstu1/immunization-example.json').toString('utf8'));
+            var fhir = new Fhir(Fhir.DSTU1);
+            var result = fhir.ValidateJSResource(immunizationJson);
+
+            assert(result);
+            assert.equal(result.valid, true);
+
+            assert(result.errors);
+            assert.equal(result.errors.length, 0);
+        });
+
         it ('should return 3 validation errors for bundle', function() {
             var bundleJson = fs.readFileSync('./test/data/dstu1/bundle.json').toString('utf8');
             var bundle = JSON.parse(bundleJson);

--- a/test/dstu2/validationTests.js
+++ b/test/dstu2/validationTests.js
@@ -78,5 +78,17 @@ describe('DSTU2: Validation', function() {
           assert(result.errors);
           assert.equal(result.errors.length, 1);
         });
+
+        it('should validate immunization-example.json successfully', function() {
+            var immunizationJson = JSON.parse(fs.readFileSync('./test/data/dstu2/immunization-example.json').toString('utf8'));
+            var fhir = new Fhir(Fhir.DSTU2);
+            var result = fhir.ValidateJSResource(immunizationJson);
+
+            assert(result);
+            assert.equal(result.valid, true);
+
+            assert(result.errors);
+            assert.equal(result.errors.length, 0);
+        });
     });
 });

--- a/test/stu3/validationTests.js
+++ b/test/stu3/validationTests.js
@@ -79,5 +79,17 @@ describe('STU3: Validation', function() {
           assert(result.errors);
           assert.equal(result.errors.length, 1);
         });
+
+        it('should validate immunization-example.json successfully', function() {
+            var immunizationJson = JSON.parse(fs.readFileSync('./test/data/stu3/immunization-example.json').toString('utf8'));
+            var fhir = new Fhir(Fhir.STU3);
+            var result = fhir.ValidateJSResource(immunizationJson);
+
+            assert(result);
+            assert.equal(result.valid, true);
+
+            assert(result.errors);
+            assert.equal(result.errors.length, 0);
+        });
     });
 });


### PR DESCRIPTION
Following on from https://github.com/lantanagroup/FHIR.js/pull/11.

This is a patch fix for version 3.3.0.

We are running into an issue when trying to validate resources which have a value of false for boolean fields which are required. I've illustrated the issue in the tests using the example immunization resources from the FHIR docs. The tests were failing before the patch was applied and are passing now.

We would really appreciate it if you can do a version 3.3.1 release since we need to support DSTU2 so are unable to upgrade to version 4. I'm happy to resolve the conflicts afterwards so that this can be merged into master.