### PR TITLE
Upgrade: move off vulnerable version of lodash (fixes #20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "path": "^0.12.7",
     "q": "^1.4.1",
     "randomatic": "^3.1.0",


### PR DESCRIPTION
See #20 for notes about this dependency