### PR TITLE
feat: Allow modifying parentBackboneElement

### DIFF
--- a/parseConformance.js
+++ b/parseConformance.js
@@ -347,6 +347,9 @@ class ParseConformance {
                         _required: backboneElement.min === 1,
                         _properties: []
                     };
+                    if (parentBackboneElement._properties === undefined || parentBackboneElement._properties === null) {
+                        parentBackboneElement._properties = [];    
+                    }
                     parentBackboneElement._properties.push(newProperty);
                     this.populateValueSet(backboneElement, newProperty);
                     if (backboneElement.type[0].code === 'BackboneElement' || backboneElement.type[0].code == 'Element') {


### PR DESCRIPTION
Add a check for an empty `_properties` object and create an array if it doesn't exist

In reference to issue #27 