### PR TITLE
Deserialization of ValueSets with exclude rules to JSON is broken

### DIFF
--- a/convertToJs.ts
+++ b/convertToJs.ts
@@ -5,7 +5,7 @@ import {ParsedProperty} from "./model/parsed-property";
 
 export class ConvertToJs {
     private parser: ParseConformance;
-    
+
     constructor(parser?: ParseConformance) {
         this.parser = parser || new ParseConformance(true);
     }
@@ -178,6 +178,7 @@ export class ConvertToJs {
                 throw new Error('Could not find reference to element definition ' + relativeType);
             }
 
+            relativeType._name = property._name;
             relativeType._multiple = property._multiple;
             relativeType._required = property._required;
 
@@ -392,7 +393,7 @@ export class ConvertToJs {
             TODO: Maybe consider preserving the comments in JSON format.
             However, according to a FHIR Chat conversation, fhir_comments won't be supported in JSON going forward
             https://chat.fhir.org/#narrow/stream/4-implementers/subject/fhir_comments
-    
+
             const xmlPropertyIndex = xmlObj.elements.indexOf(xmlProperty[i]);
             const xmlComment = xmlPropertyIndex > 0 && xmlObj.elements[xmlPropertyIndex-1].type === 'comment' ?
                 xmlObj.elements[xmlPropertyIndex-1] :


### PR DESCRIPTION
The test suite should be extended. I guess backbone elements with type references are not covered yet.

**Given**

```
<?xml version="1.0" encoding="UTF-8"?>
<ValueSet xmlns="http://hl7.org/fhir">
    <url value="https://fhir.kbv.de/ValueSet/KBV_VS_AW_Patient_VSDM_Gender" />
    <version value="1.2.0" />
    <name value="KBV_VS_AW_Patient_VSDM_Gender" />
    <status value="active" />
    <experimental value="false" />
    <date value="2018-10-06" />
    <publisher value="Kassenaerztliche Bundesvereinigung" />
    <contact>
        <telecom>
            <system value="url" />
            <value value="http://www.kbv.de" />
        </telecom>
    </contact>
    <description value="Genderauswahl zur Nutzung in VSDM Extension" />
    <copyright value="Kassenaerztliche Bundesvereinigung" />
    <compose>
        <include>
            <valueSet value="http://hl7.org/fhir/ValueSet/administrative-gender" />
        </include>
        <include>
            <valueSet value="http://fhir.de/ValueSet/gender-amtlich-de" />
        </include>
        <exclude>
            <system value="http://hl7.org/fhir/administrative-gender" />
            <concept>
                <code value="other" />
            </concept>
        </exclude>
    </compose>
</ValueSet>
```

**Expected**
```
{
    "resourceType": "ValueSet",
    "url": "https://fhir.kbv.de/ValueSet/KBV_VS_AW_Patient_VSDM_Gender",
    "version": "1.2.0",
    "name": "KBV_VS_AW_Patient_VSDM_Gender",
    "status": "active",
    "experimental": false,
    "date": "2018-10-06",
    "publisher": "Kassenaerztliche Bundesvereinigung",
    "contact": [
        {
            "telecom": [
                {
                    "system": "url",
                    "value": "http://www.kbv.de"
                }
            ]
        }
    ],
    "description": "Genderauswahl zur Nutzung in VSDM Extension",
    "copyright": "Kassenaerztliche Bundesvereinigung",
    "compose": {
        "include": [
            {
                "valueSet": [
                    "http://hl7.org/fhir/ValueSet/administrative-gender"
                ]
            },
            {
                "valueSet": [
                    "http://fhir.de/ValueSet/gender-amtlich-de"
                ]
            }
        ],
        "exclude": [
            {
                "system": "http://hl7.org/fhir/administrative-gender",
                "concept": [
                    {
                        "code": "other"
                    }
                ]
            }
        ]
    }
}
```

**Actual**

```
{
    "resourceType": "ValueSet",
    "url": "https://fhir.kbv.de/ValueSet/KBV_VS_AW_Patient_VSDM_Gender",
    "version": "1.2.0",
    "name": "KBV_VS_AW_Patient_VSDM_Gender",
    "status": "active",
    "experimental": false,
    "date": "2018-10-06",
    "publisher": "Kassenaerztliche Bundesvereinigung",
    "contact": [
        {
            "telecom": [
                {
                    "system": "url",
                    "value": "http://www.kbv.de"
                }
            ]
        }
    ],
    "description": "Genderauswahl zur Nutzung in VSDM Extension",
    "copyright": "Kassenaerztliche Bundesvereinigung",
    "compose": {
        "include": [
            {
                "system": "http://hl7.org/fhir/administrative-gender",
                "concept": [
                    {
                        "code": "other"
                    }
                ]
            }
        ]
    }
}
```